### PR TITLE
Removed Framework addition to embedded frameworks in Xcode project

### DIFF
--- a/Editor/PurchaselyPostProcessor.cs
+++ b/Editor/PurchaselyPostProcessor.cs
@@ -44,7 +44,9 @@ namespace Purchasely.Editor
 			var frameworkPath = project.AddFile(src, src);
         
 			project.AddFileToBuild(mainTargetGUID, frameworkPath);
-			project.AddFileToEmbedFrameworks(mainTargetGUID, frameworkPath);
+			
+			// Appears to be useless
+			// project.AddFileToEmbedFrameworks(mainTargetGUID, frameworkPath);
 
 			project.WriteToFile(projPath);
 		}


### PR DESCRIPTION
I removed the call to AddFileToEmbedFrameworks to fix:
```
error: Multiple commands produce '/build/ReleaseForRunning-iphoneos/Application.app/Frameworks/Purchasely.framework'
    note: Target 'Unity-iPhone' (project 'Unity-iPhone') has copy command from '/Pods/Purchasely/Purchasely/Frameworks/Purchasely.xcframework/ios-arm64/Purchasely.framework' to '/build/ReleaseForRunning-iphoneos/Application.app/Frameworks/Purchasely.framework'
    note: That command depends on command in Target 'Unity-iPhone' (project 'Unity-iPhone'): script phase “[CP] Embed Pods Frameworks”
```

I only commented it though